### PR TITLE
change quickgame-cli to version 0.1.10-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
       ]
   },
   "dependencies": {
-    "quickgame-cli": "^0.1.10"
+    "quickgame-cli": "0.1.10-beta.2"
   }
 }


### PR DESCRIPTION
小米他们版本比较奇怪，beta.2的版本带了--ignore参数，但是beta.3没有，所以我们不能用^去匹配他们的最新版本，只能指定版本
https://github.com/cocos-creator/2d-tasks/issues/1396