### PR TITLE
fix xiaomi platform init

### DIFF
--- a/xiaomigame/adapter/engine/Platform.js
+++ b/xiaomigame/adapter/engine/Platform.js
@@ -1,5 +1,5 @@
 // check macro in CCSys.js
-const XIAOMI_GAME = 110;
+const XIAOMI_GAME = 111;
 const OS_ANDROID = 'Android';
 const OS_IOS = 'iOS';
 const BROWSER_TYPE_XIAOMI_GAME = 'xiaomigame';


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1408

小米平台跟新加入的华为平台冲突了，引擎层的平台数字每次修改完，需要关联适配层修改。
适配层在引擎初始化之前没办法获得 `cc.sys.XIAOMI_GAME` 的宏定义，暂时只能写死数据