### PR TITLE
add audio stop fix 2d-tasks/issues/1444

### DIFF
--- a/xiaomigame/adapter/engine/Audio.js
+++ b/xiaomigame/adapter/engine/Audio.js
@@ -34,6 +34,14 @@ Object.assign(Audio.prototype, {
         this._element.play();
     },
 
+    stop () {
+        if (!this._element) return;
+        this._element.stop();
+        this._unbindEnded();
+        this.emit('stop');
+        this._state = Audio.State.STOPPED;
+    },
+
     setCurrentTime (num) {
         // TODO: To ensure innerAudioContext loaded
         if (this._element) {


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/1444

修改 stop 函数，直接调用微信小游戏的 stop 即可，之前的 stop 是先 pause 音频，然后设置 crrentTime 为 0，这个方法不适用于微信小游戏会变成 stop 后，获取 crrrentTime 还是原来的数值，不会归 0