### PR TITLE
fix retina on xiaomi quickgame

### DIFF
--- a/xiaomigame/adapter/mi-builtin.js
+++ b/xiaomigame/adapter/mi-builtin.js
@@ -227,7 +227,7 @@
 	var _window = window;
 
 	var _qg$getSystemInfoSync = qg.getSystemInfoSync(),
-	    devicePixelRatio = _qg$getSystemInfoSync.devicePixelRatio;
+	    devicePixelRatio = _qg$getSystemInfoSync.pixelRatio;
 
 	var innerWidth = exports.innerWidth = _window.innerWidth;
 	var innerHeight = exports.innerHeight = _window.innerHeight;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1468

changeLog:
- 修复小米字体模糊问题

![image](https://user-images.githubusercontent.com/17872773/58378026-5c443b00-7fbe-11e9-85e8-786b72f0b68e.png)
![image](https://user-images.githubusercontent.com/17872773/58378028-61a18580-7fbe-11e9-9f8e-326c45be79eb.png)
