### PR TITLE
fix audio distroy

### DIFF
--- a/xiaomigame/adapter/engine/Audio.js
+++ b/xiaomigame/adapter/engine/Audio.js
@@ -54,7 +54,9 @@ Object.assign(Audio.prototype, {
     },
 
     destroy () {
-        this._element.destroy();
-        this._element = null;
+        if (this._element) {
+            this._element.destroy();
+            this._element = null;
+        }
     },
 });


### PR DESCRIPTION
changeLog:
- 修复 Audio 销毁时的报错

测试例：04_audio/AudioSource 没有播放音乐，直接切场景，会报错 _element 不存在