### PR TITLE
build including pem file on xiaomi platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "build-template": "xiaomigame",
   "scripts": {
-      "build": "quickgame build --cocos-wx-game",
-      "release": "quickgame release --cocos-wx-game",
+      "build": "quickgame build --cocos-wx-game --include-file-ext .pem",
+      "release": "quickgame release --cocos-wx-game --include-file-ext .pem",
       "server": "quickgame server",
       "debug": "quickgame debug"
   },


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1735

changeLog:
- 修复小米平台没有将 pem 证书打包进去，导致找不到 pem 资源的问题

需要更新 quickgame-cli 到 0.1.16 版本